### PR TITLE
Adds external versioning support for bulk indexing operations!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ go:
 
 env:
   matrix:
-    - ES_VERSION=1.1.2
-    - ES_VERSION=1.2.1
+    - ES_VERSION=1.3.4
+    - ES_VERSION=1.4.4
     - ES_VERSION=1.7.3
 before_script:
   - mkdir ${HOME}/elasticsearch
-  - wget http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - wget http://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C ${HOME}/elasticsearch
   - ${HOME}/elasticsearch/elasticsearch-${ES_VERSION}/bin/elasticsearch >/dev/null &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: go
 
 go:
-  - 1.1
   - 1.2
   - 1.3
+  - 1.5
   - tip
 
 env:
   matrix:
-    - ES_VERSION=1.0.3
     - ES_VERSION=1.1.2
     - ES_VERSION=1.2.1
-
+    - ES_VERSION=1.7.3
 before_script:
   - mkdir ${HOME}/elasticsearch
   - wget http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz

--- a/example_test.go
+++ b/example_test.go
@@ -6,12 +6,11 @@ package goes_test
 
 import (
 	"fmt"
+	"github.com/pib/goes"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
-
-	"github.com/belogik/goes"
 )
 
 var (

--- a/goes.go
+++ b/goes.go
@@ -147,12 +147,17 @@ func (c *Connection) BulkSend(documents []Document) (*Response, error) {
 	i := 0
 
 	for _, doc := range documents {
+		bulkCommand := map[string]interface{}{
+			"_index": doc.Index,
+			"_type":  doc.Type,
+			"_id":    doc.Id,
+		}
+		if doc.VersionType != "" {
+			bulkCommand["_version"] = doc.Version
+			bulkCommand["_version_type"] = doc.VersionType
+		}
 		action, err := json.Marshal(map[string]interface{}{
-			doc.BulkCommand: map[string]interface{}{
-				"_index": doc.Index,
-				"_type":  doc.Type,
-				"_id":    doc.Id,
-			},
+			doc.BulkCommand: bulkCommand,
 		})
 
 		if err != nil {

--- a/goes_test.go
+++ b/goes_test.go
@@ -834,7 +834,7 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 				"total_size_in_bytes":   float64(0),
 			},
 			Refresh: map[string]interface{}{
-				"total":                float64(0),
+				"total":                float64(1),
 				"total_time_in_millis": float64(0),
 			},
 			Flush: map[string]interface{}{

--- a/goes_test.go
+++ b/goes_test.go
@@ -100,7 +100,7 @@ func (s *GoesTestSuite) TestEsDown(c *C) {
 	}
 	_, err := r.Run()
 
-	c.Assert(err, ErrorMatches, "Get http://a.b.c.d:1234/i/_search:(.*)lookup a.b.c.d: no such host")
+	c.Assert(err, ErrorMatches, "Get http://a.b.c.d:1234/i/_search:(.*)lookup a.b.c.d(.*): no such host")
 }
 
 func (s *GoesTestSuite) TestRunMissingIndex(c *C) {

--- a/goes_test.go
+++ b/goes_test.go
@@ -797,6 +797,8 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 
 	// gives ES some time to do its job
 	time.Sleep(1 * time.Second)
+	_, err = conn.RefreshIndex(indexName)
+	c.Assert(err, IsNil)
 
 	response, err := conn.IndexStatus([]string{"testindexstatus"})
 	c.Assert(err, IsNil)
@@ -806,9 +808,11 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 
 	primarySizeInBytes := response.Indices[indexName].Index["primary_size_in_bytes"].(float64)
 	sizeInBytes := response.Indices[indexName].Index["size_in_bytes"].(float64)
+	refreshTotal := response.Indices[indexName].Refresh["total"].(float64)
 
 	c.Assert(primarySizeInBytes > 0, Equals, true)
 	c.Assert(sizeInBytes > 0, Equals, true)
+	c.Assert(refreshTotal > 0, Equals, true)
 
 	expectedIndices := map[string]IndexStatus{
 		indexName: {
@@ -834,7 +838,7 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 				"total_size_in_bytes":   float64(0),
 			},
 			Refresh: map[string]interface{}{
-				"total":                float64(1),
+				"total":                refreshTotal,
 				"total_time_in_millis": float64(0),
 			},
 			Flush: map[string]interface{}{

--- a/goes_test.go
+++ b/goes_test.go
@@ -154,7 +154,7 @@ func (s *GoesTestSuite) TestDeleteIndexInexistantIndex(c *C) {
 	resp, err := conn.DeleteIndex("foobar")
 
 	c.Assert(err.Error(), Equals, "[404] IndexMissingException[[foobar] missing]")
-	c.Assert(resp, DeepEquals, Response{})
+	c.Assert(*resp, DeepEquals, Response{Status: 404})
 }
 
 func (s *GoesTestSuite) TestDeleteIndexExistingIndex(c *C) {
@@ -169,9 +169,9 @@ func (s *GoesTestSuite) TestDeleteIndexExistingIndex(c *C) {
 	resp, err := conn.DeleteIndex(indexName)
 	c.Assert(err, IsNil)
 
-	expectedResponse := Response{}
+	expectedResponse := Response{Status: 200}
 	expectedResponse.Acknowledged = true
-	c.Assert(resp, DeepEquals, expectedResponse)
+	c.Assert(*resp, DeepEquals, expectedResponse)
 }
 
 func (s *GoesTestSuite) TestRefreshIndex(c *C) {
@@ -355,13 +355,14 @@ func (s *GoesTestSuite) TestIndexWithFieldsInStruct(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse := Response{
+		Status:  201,
 		Index:   indexName,
 		Id:      docId,
 		Type:    docType,
 		Version: 1,
 	}
 
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 }
 
 func (s *GoesTestSuite) TestIndexWithFieldsNotInMapOrStruct(c *C) {
@@ -419,13 +420,14 @@ func (s *GoesTestSuite) TestIndexIdDefined(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse := Response{
+		Status:  201,
 		Index:   indexName,
 		Id:      docId,
 		Type:    docType,
 		Version: 1,
 	}
 
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 }
 
 func (s *GoesTestSuite) TestIndexIdNotDefined(c *C) {
@@ -487,27 +489,29 @@ func (s *GoesTestSuite) TestDelete(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse := Response{
-		Found: true,
-		Index: indexName,
-		Type:  docType,
-		Id:    docId,
+		Status: 200,
+		Found:  true,
+		Index:  indexName,
+		Type:   docType,
+		Id:     docId,
 		// XXX : even after a DELETE the version number seems to be incremented
 		Version: 2,
 	}
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 
 	response, err = conn.Delete(d, url.Values{})
 	c.Assert(err, IsNil)
 
 	expectedResponse = Response{
-		Found: false,
-		Index: indexName,
-		Type:  docType,
-		Id:    docId,
+		Status: 404,
+		Found:  false,
+		Index:  indexName,
+		Type:   docType,
+		Id:     docId,
 		// XXX : even after a DELETE the version number seems to be incremented
 		Version: 3,
 	}
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 }
 
 func (s *GoesTestSuite) TestDeleteByQuery(c *C) {
@@ -560,13 +564,14 @@ func (s *GoesTestSuite) TestDeleteByQuery(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse := Response{
+		Status:  200,
 		Found:   false,
 		Index:   "",
 		Type:    "",
 		Id:      "",
 		Version: 0,
 	}
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 
 	//should be 0 docs after delete by query
 	response, err = conn.Search(query, []string{indexName}, []string{docType}, url.Values{})
@@ -604,6 +609,7 @@ func (s *GoesTestSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse := Response{
+		Status:  200,
 		Index:   indexName,
 		Type:    docType,
 		Id:      docId,
@@ -612,7 +618,7 @@ func (s *GoesTestSuite) TestGet(c *C) {
 		Source:  source,
 	}
 
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 
 	fields := make(url.Values, 1)
 	fields.Set("fields", "f1")
@@ -620,6 +626,7 @@ func (s *GoesTestSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedResponse = Response{
+		Status:  200,
 		Index:   indexName,
 		Type:    docType,
 		Id:      docId,
@@ -630,7 +637,7 @@ func (s *GoesTestSuite) TestGet(c *C) {
 		},
 	}
 
-	c.Assert(response, DeepEquals, expectedResponse)
+	c.Assert(*response, DeepEquals, expectedResponse)
 }
 
 func (s *GoesTestSuite) TestSearch(c *C) {
@@ -748,7 +755,7 @@ func (s *GoesTestSuite) TestIndexStatus(c *C) {
 				"total_size_in_bytes":   float64(0),
 			},
 			Refresh: map[string]interface{}{
-				"total":                float64(1),
+				"total":                float64(0),
 				"total_time_in_millis": float64(0),
 			},
 			Flush: map[string]interface{}{

--- a/structs.go
+++ b/structs.go
@@ -115,6 +115,8 @@ type Document struct {
 	Index       interface{}
 	Type        string
 	Id          interface{}
+	Version     int
+	VersionType string
 	BulkCommand string
 	Fields      interface{}
 }


### PR DESCRIPTION
https://www.elastic.co/blog/elasticsearch-versioning-support

Tested with Elasticsearch 1.7.3.
Also fixed some broken tests.
